### PR TITLE
do not destroy activity on screen changes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
         <activity
             android:name=".MainActivity"
             android:label="@string/app_name"
+            android:configChanges="orientation|screenSize"
             android:theme="@style/AppTheme.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>


### PR DESCRIPTION
If the screen is rotated or the size changes,
do not destroy the activity and re-create it.
Doing so will stop the currently playing sound.