### PR TITLE
Reduce min SDK version to 10

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,7 +12,7 @@ android {
 
     defaultConfig {
         applicationId "protect.babysleepsounds"
-        minSdkVersion 17
+        minSdkVersion 10
         targetSdkVersion 23
         versionCode 3
         versionName "0.3"


### PR DESCRIPTION
The selection of SDK 17 was arbitrarily based on the version
available on my device at the time. As no APIs are being used
at that level, a lower SDK version can be targeted.

According to the current distribution of Android device versions,
99.9% of devices are at SDK 10+. Changing to this for the min SDK
for now.