### PR TITLE
Update travis config with info on storage space

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,4 @@ script: ./gradlew build lint findbugs test
 after_failure:
 - cat app/build/outputs/lint-results.xml
 - cat app/build/reports/findbugs/findbugs.html
+- df -h


### PR DESCRIPTION
There is a known issue on Travis-CI where the sudo enabled containers are sometimes running out of space whereas before they were running successfully. Adding some extra debug in case this happens.