### PR TITLE
Build in parallel during Travis-CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ android:
     # Additional components
     - extra
 
-script: ./gradlew build lint findbugs test
+script: ./gradlew --parallel build lint findbugs test
 
 after_failure:
 - cat app/build/outputs/lint-results.xml


### PR DESCRIPTION
Use the --parallel flag when building and testing with gradle,
to hopefully reduce build and test times.