### PR TITLE
Check that progress bar exists before accessing

### DIFF
--- a/app/src/main/java/protect/babysleepsounds/MainActivity.java
+++ b/app/src/main/java/protect/babysleepsounds/MainActivity.java
@@ -461,8 +461,11 @@ public class MainActivity extends AppCompatActivity
 
                 setControlsEnabled(false);
 
-                _encodingProgress.hide();
-                _encodingProgress = null;
+                if(_encodingProgress != null)
+                {
+                    _encodingProgress.hide();
+                    _encodingProgress = null;
+                }
             }
         });
     }


### PR DESCRIPTION
It was found that the _encodingProgress object can be null here,
though th circumstances are not known as the crash was reported
via a device on the Google developer console. As in other places
the progress dialog is checked for null, this change also adds
the check here.