### PR TITLE
Migrate to Android Studio 3.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ android:
     - tools
 
     # The BuildTools version used by your project
-    - build-tools-23.0.2
+    - build-tools-26.0.2
 
     # The SDK version used to compile your project
     - android-23

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,6 @@ findbugs {
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.2"
 
     defaultConfig {
         applicationId "protect.babysleepsounds"
@@ -46,7 +45,7 @@ dependencies {
     compile 'com.writingminds:FFmpegAndroid:0.3.2'
 }
 
-task findbugs(type: FindBugs, dependsOn: assembleDebug) {
+task findbugs(type: FindBugs, dependsOn: 'assembleDebug') {
 
     description 'Run findbugs'
     group 'verification'

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,12 @@
 buildscript {
     repositories {
         jcenter()
+
+        // For the Android Gradle plugin
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Aug 26 21:22:17 EDT 2016
+#Mon Dec 25 18:47:13 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
Changes required for the migration:
- Android Gradle plugin no longer available in jcenter,
  but in its own repository: google()
- No longer need to specify the build tools used, as the
  Android Gradle plugin specifies which one to use.
  (Travis CI still needs it defined, and it is updated).
- New gradle version is used.
- FindBugs task needs to have dependsOn target in quotes.