### PR TITLE
Play audio from a foreground service

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,9 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <service
+            android:name=".AudioService" >
+        </service>
     </application>
 
 </manifest>

--- a/app/src/main/java/protect/babysleepsounds/AudioService.java
+++ b/app/src/main/java/protect/babysleepsounds/AudioService.java
@@ -1,0 +1,92 @@
+package protect.babysleepsounds;
+
+import android.app.PendingIntent;
+import android.app.Service;
+import android.content.Intent;
+import android.os.IBinder;
+import android.support.annotation.Nullable;
+import android.support.v4.app.NotificationCompat;
+import android.util.Log;
+
+import java.io.File;
+
+public class AudioService extends Service
+{
+    private final static String TAG = "BabySleepSounds";
+
+    private static final int NOTIFICATION_ID = 1;
+
+    public static final String AUDIO_FILENAME_ARG = "AUDIO_FILENAME_ARG";
+
+    private LoopingAudioPlayer _mediaPlayer;
+
+    @Nullable
+    @Override
+    public IBinder onBind(Intent intent)
+    {
+        // Used only in case of bound services.
+        return null;
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId)
+    {
+        String audioFilename = intent.getStringExtra(AUDIO_FILENAME_ARG);
+        if(audioFilename != null)
+        {
+            Log.i(TAG, "Received intent to start playback");
+            if(_mediaPlayer != null)
+            {
+                _mediaPlayer.stop();
+            }
+            _mediaPlayer = new LoopingAudioPlayer(this, new File(audioFilename));
+            _mediaPlayer.start();
+
+            setNotification();
+        }
+        else
+        {
+            Log.i(TAG, "Received intent to stop playback");
+
+            if(_mediaPlayer != null)
+            {
+                _mediaPlayer.stop();
+                _mediaPlayer = null;
+            }
+
+            stopForeground(true);
+            stopSelf();
+        }
+
+        // If this service is killed, let is remain dead until explicitly started again.
+        return START_NOT_STICKY;
+    }
+
+    private void setNotification()
+    {
+        NotificationCompat.Builder builder =
+                new NotificationCompat.Builder(this)
+                        .setOngoing(true)
+                        .setSmallIcon(R.drawable.playing_notification)
+                        .setContentTitle(getString(R.string.app_name))
+                        .setContentText(getString(R.string.notificationPlaying));
+
+        // Creates an explicit intent for the Activity
+        Intent resultIntent = new Intent(this, MainActivity.class);
+
+        PendingIntent resultPendingIntent = PendingIntent.getActivity(this, 0,
+                resultIntent, 0);
+        builder.setContentIntent(resultPendingIntent);
+
+        startForeground(NOTIFICATION_ID, builder.build());
+    }
+
+    @Override
+    public void onDestroy()
+    {
+        if(_mediaPlayer != null)
+        {
+            _mediaPlayer.stop();
+        }
+    }
+}

--- a/app/src/main/java/protect/babysleepsounds/MainActivity.java
+++ b/app/src/main/java/protect/babysleepsounds/MainActivity.java
@@ -77,7 +77,7 @@ public class MainActivity extends AppCompatActivity
 
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
-        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+        Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
 
         // These sound files by convention are:
@@ -115,7 +115,7 @@ public class MainActivity extends AppCompatActivity
                 .put(getResources().getString(R.string.time_8hour), 1000*60*60*8)
                 .build();
 
-        final Spinner soundSpinner = (Spinner) findViewById(R.id.soundSpinner);
+        final Spinner soundSpinner = findViewById(R.id.soundSpinner);
 
         List<String> names = new ArrayList<>(_soundMap.keySet());
 
@@ -125,7 +125,7 @@ public class MainActivity extends AppCompatActivity
         soundSpinner.setAdapter(dataAdapter);
 
 
-        final Spinner sleepTimeoutSpinner = (Spinner) findViewById(R.id.sleepTimerSpinner);
+        final Spinner sleepTimeoutSpinner = findViewById(R.id.sleepTimerSpinner);
         List<String> times = new ArrayList<>(_timeMap.keySet());
         sleepTimeoutSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener()
         {
@@ -153,7 +153,7 @@ public class MainActivity extends AppCompatActivity
 
         setVolumeControlStream(AudioManager.STREAM_MUSIC);
 
-        final Button button = (Button) findViewById(R.id.button);
+        final Button button = findViewById(R.id.button);
         button.setOnClickListener(new View.OnClickListener()
         {
             @Override
@@ -212,7 +212,7 @@ public class MainActivity extends AppCompatActivity
 
         final View filterFrequencyReadout = findViewById(R.id.filterFrequencyReadout);
         final View filterFrequencyLayout = findViewById(R.id.filterFrequencyLayout);
-        _enableFilterSetting = (CheckBox)findViewById(R.id.enableFilter);
+        _enableFilterSetting = findViewById(R.id.enableFilter);
         _enableFilterSetting.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener()
         {
             @Override
@@ -223,7 +223,7 @@ public class MainActivity extends AppCompatActivity
             }
         });
 
-        _filterCutoffFrequencySetting = (SeekBar)findViewById(R.id.filterFrequencyBar);
+        _filterCutoffFrequencySetting = findViewById(R.id.filterFrequencyBar);
         _filterCutoffFrequencySetting.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener()
         {
             @Override
@@ -248,7 +248,7 @@ public class MainActivity extends AppCompatActivity
         // Set initial value
         updateFrequencyReadout(getFrequencyReadout());
 
-        _useDarkTheme = (CheckBox)findViewById(R.id.useDarkTheme);
+        _useDarkTheme = findViewById(R.id.useDarkTheme);
         _useDarkTheme.setChecked(pref.getBoolean("useDarkTheme",false));
         _useDarkTheme.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener()
         {
@@ -282,7 +282,7 @@ public class MainActivity extends AppCompatActivity
      */
     private void updateFrequencyReadout(int frequency)
     {
-        final TextView filterFrequency = (TextView) findViewById(R.id.filterFrequencyText);
+        final TextView filterFrequency = findViewById(R.id.filterFrequencyText);
         String readout = String.format(getString(R.string.filterCutoff), frequency);
         filterFrequency.setText(readout);
     }
@@ -297,7 +297,7 @@ public class MainActivity extends AppCompatActivity
 
     private void startPlayback()
     {
-        final Spinner soundSpinner = (Spinner) findViewById(R.id.soundSpinner);
+        final Spinner soundSpinner = findViewById(R.id.soundSpinner);
         String selectedSound = (String)soundSpinner.getSelectedItem();
         int id = _soundMap.get(selectedSound);
 
@@ -454,7 +454,7 @@ public class MainActivity extends AppCompatActivity
             _timer.purge();
         }
 
-        final Spinner sleepTimeoutSpinner = (Spinner) findViewById(R.id.sleepTimerSpinner);
+        final Spinner sleepTimeoutSpinner = findViewById(R.id.sleepTimerSpinner);
         String selectedTimeout = (String)sleepTimeoutSpinner.getSelectedItem();
         int timeoutMs = _timeMap.get(selectedTimeout);
         if(timeoutMs > 0)
@@ -485,7 +485,7 @@ public class MainActivity extends AppCompatActivity
             {
                 updatePlayTimeout();
 
-                final Button button = (Button) findViewById(R.id.button);
+                final Button button = findViewById(R.id.button);
                 button.setText(R.string.stop);
 
                 setControlsEnabled(false);
@@ -518,7 +518,7 @@ public class MainActivity extends AppCompatActivity
             @Override
             public void run()
             {
-                final Button button = (Button) findViewById(R.id.button);
+                final Button button = findViewById(R.id.button);
                 button.setText(R.string.play);
 
                 setControlsEnabled(true);


### PR DESCRIPTION
Android will periodically look through the list of apps which are running in the background. If they are holding a wakelock the app is killed.
    
This app would hold a wakelock, but was doing so from an Activity. When the Activity goes to the background Androidbelieves the wakelock hold is in error and does not honor it. To get around this, the audio playback is moved to a Service. The Service registers as a foreground service. Then, when it holds a lock Android will not attempt to kill it.

https://github.com/brarcher/baby-sleep-sounds/issues/65