### PR TITLE
Set a notification channel for FFmpeg service

### DIFF
--- a/app/src/main/java/protect/babysleepsounds/AudioService.java
+++ b/app/src/main/java/protect/babysleepsounds/AudioService.java
@@ -1,10 +1,16 @@
 package protect.babysleepsounds;
 
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.app.Service;
+import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.os.IBinder;
 import android.support.annotation.Nullable;
+import android.support.annotation.RequiresApi;
 import android.support.v4.app.NotificationCompat;
 import android.util.Log;
 
@@ -15,6 +21,7 @@ public class AudioService extends Service
     private final static String TAG = "BabySleepSounds";
 
     private static final int NOTIFICATION_ID = 1;
+    private static final String NOTIFICATION_CHANNEL_ID = TAG;
 
     public static final String AUDIO_FILENAME_ARG = "AUDIO_FILENAME_ARG";
 
@@ -64,8 +71,14 @@ public class AudioService extends Service
 
     private void setNotification()
     {
+        String channelId = "";
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+        {
+            channelId = createNotificationChannel();
+        }
+
         NotificationCompat.Builder builder =
-                new NotificationCompat.Builder(this)
+                new NotificationCompat.Builder(this, channelId)
                         .setOngoing(true)
                         .setSmallIcon(R.drawable.playing_notification)
                         .setContentTitle(getString(R.string.app_name))
@@ -80,6 +93,28 @@ public class AudioService extends Service
 
         startForeground(NOTIFICATION_ID, builder.build());
     }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private String createNotificationChannel()
+    {
+        String channelId = NOTIFICATION_CHANNEL_ID;
+        String channelName = getString(R.string.notificationChannelName);
+        NotificationChannel chan = new NotificationChannel(channelId,
+                channelName, NotificationManager.IMPORTANCE_LOW);
+        chan.setLockscreenVisibility(Notification.VISIBILITY_PRIVATE);
+        NotificationManager service = (NotificationManager)getSystemService(Context.NOTIFICATION_SERVICE);
+        if(service != null)
+        {
+            service.createNotificationChannel(chan);
+        }
+        else
+        {
+            Log.w(TAG, "Could not get NotificationManager");
+        }
+
+        return channelId;
+    }
+
 
     @Override
     public void onDestroy()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,6 +45,8 @@
 
     <string name="notificationPlaying">Playing&#8230;</string>
 
+    <string name="notificationChannelName">Baby Sleep Sounds Audio Service</string>
+
     <string name="about">About</string>
     <string name="app_copyright_fmt">Copyright 2016-<xliff:g>%d</xliff:g> Branden Archer</string>
     <string name="app_license">Licensed under the GPLv3.</string>


### PR DESCRIPTION
On Android 8.1 a notification channel is required for background
services. As one was not being created, a RemoteServiceException was
being thrown when encoding was attempted.

https://github.com/brarcher/baby-sleep-sounds/issues/72