### PR TITLE
Persist low pass filter settings.

### DIFF
--- a/app/src/main/java/protect/babysleepsounds/MainActivity.java
+++ b/app/src/main/java/protect/babysleepsounds/MainActivity.java
@@ -181,9 +181,17 @@ public class MainActivity extends AppCompatActivity
             reportPlaybackUnsupported();
         }
 
+        final Preferences preferences = Preferences.get(this);
+
         final View filterFrequencyReadout = findViewById(R.id.filterFrequencyReadout);
         final View filterFrequencyLayout = findViewById(R.id.filterFrequencyLayout);
+
+        int filterVisibility = preferences.isLowPassFilterEnabled() ? View.VISIBLE : View.GONE;
+        filterFrequencyReadout.setVisibility(filterVisibility);
+        filterFrequencyLayout.setVisibility(filterVisibility);
+
         _enableFilterSetting = findViewById(R.id.enableFilter);
+        _enableFilterSetting.setChecked(preferences.isLowPassFilterEnabled());
         _enableFilterSetting.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener()
         {
             @Override
@@ -191,10 +199,12 @@ public class MainActivity extends AppCompatActivity
             {
                 filterFrequencyLayout.setVisibility(isChecked ? View.VISIBLE : View.GONE);
                 filterFrequencyReadout.setVisibility(isChecked ? View.VISIBLE : View.GONE);
+                preferences.setLowPassFilterEnabled(isChecked);
             }
         });
 
         _filterCutoffFrequencySetting = findViewById(R.id.filterFrequencyBar);
+        _filterCutoffFrequencySetting.setProgress(toFrequencyReadout(preferences.getLowPassFilterFrequency()));
         _filterCutoffFrequencySetting.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener()
         {
             @Override
@@ -248,7 +258,17 @@ public class MainActivity extends AppCompatActivity
     }
 
     /**
-     * Update the TextView containing the frequency to the given value
+     * Opposite of {@link MainActivity#getFrequencyReadout()}. Used when we have a
+     * frequency value that we use to populate the frequency bar.
+     * @return
+     */
+    private int toFrequencyReadout(int frequency) {
+        return frequency - 200;
+    }
+
+    /**
+     * Update the TextView containing the frequency to the given value and remember the
+     * value in our preferences.
      * @param frequency value to update the field with
      */
     private void updateFrequencyReadout(int frequency)
@@ -256,6 +276,8 @@ public class MainActivity extends AppCompatActivity
         final TextView filterFrequency = findViewById(R.id.filterFrequencyText);
         String readout = String.format(getString(R.string.filterCutoff), frequency);
         filterFrequency.setText(readout);
+
+        Preferences.get(this).setLowPassFilterFrequency(frequency);
     }
 
     /**

--- a/app/src/main/java/protect/babysleepsounds/Preferences.java
+++ b/app/src/main/java/protect/babysleepsounds/Preferences.java
@@ -1,0 +1,48 @@
+package protect.babysleepsounds;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+
+public class Preferences {
+
+    private static final String LOW_PASS_FILTER_ENABLED = "lowPassFilterEnabled";
+    private static final String LOW_PASS_FILTER_FREQUENCY = "lowPassFilterFrequency";
+
+    private static Preferences instance;
+
+    private final SharedPreferences preferences;
+
+    private Preferences(Context context) {
+        preferences = PreferenceManager.getDefaultSharedPreferences(context);
+    }
+
+    public static Preferences get(Context context) {
+        if (instance == null) {
+            instance = new Preferences(context);
+        }
+
+        return instance;
+    }
+
+    public void setLowPassFilterEnabled(boolean enabled) {
+        preferences.edit()
+                .putBoolean(LOW_PASS_FILTER_ENABLED, enabled)
+                .apply();
+    }
+
+    public boolean isLowPassFilterEnabled() {
+        return preferences.getBoolean(LOW_PASS_FILTER_ENABLED, false);
+    }
+
+    public void setLowPassFilterFrequency(int frequency) {
+        preferences.edit()
+                .putInt(LOW_PASS_FILTER_FREQUENCY, frequency)
+                .apply();
+    }
+
+    public int getLowPassFilterFrequency() {
+        return preferences.getInt(LOW_PASS_FILTER_FREQUENCY, 1000);
+    }
+
+}


### PR DESCRIPTION
As per #70, the first item on your (pretty well thought out) wishlist regarding progressively migrating the UX was to persist the filter settings. This does that via default shared preferences.

I'm going to go look into moving these into a settings screen for a subsequent PR, to check off the next item on the list. Then I'll see if I can have a stab at the other UX related issues in that ticket.